### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Description
+
+Please provide a brief description of the changes made in this PR. Include a reference to the issue(s) being addressed, 
+if applicable.
+
+Fixes #(issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## Additional Context (optional)
+Please provide any additional information. For example, future considerations or information useful for reviewers.
+
+## Checklist:
+
+- [ ] I have performed a self-review of my own code
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings (`make lint`)
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes (`make test`)


### PR DESCRIPTION
## Description

This PR adds a pull request template to the repository to help standardize and streamline the PR creation process.

## Changes

- Add  `.github/pull_request_template.md`.

## Benefits

By adding a pull request template, we ensure that all future PRs will have a consistent format, making them easier to review and understand. This will save time and effort for both the contributors and maintainers and improve the overall quality of the project.
